### PR TITLE
Convert all cases of NumPy types to native types

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -10,17 +10,17 @@ from wires import Wire
 
 
 class Simulation():
-    def __init__(self, particles: list[PointParticle], total_ticks: int, tick_size: np.float64 = np.float64(1.0)) -> None:
+    def __init__(self, particles: list[PointParticle], total_ticks: int, tick_size: float = 1.0) -> None:
         """Initiate one simulation.
 
         Parameters
         ----------
-        particles : list
+        particles : list[PointParticle]
             A list of particles that are interacting with each other.
-        total_ticks: int
+        total_ticks : np.int_
             The duration of the simulation, measured in ticks.
-        tick_size : float, optional
-            The time increment of the simulation in seconds, by default 1.0
+        tick_size : np.float64, optional
+            The time increment of the simulation in seconds, by default np.float64(1.0)
         """
         self.particles = particles
         # A log of all the particles' positions over the course of the simulation
@@ -37,7 +37,7 @@ class Simulation():
         self.gravitational_field = np.zeros(3)
 
         self.total_ticks = total_ticks
-        self.current_tick = 0
+        self.current_tick = 0.0
         self.tick_size = tick_size
 
     def apply_force_between_particles(self, particle1: PointParticle, particle2: PointParticle) -> None:

--- a/src/particle.py
+++ b/src/particle.py
@@ -15,43 +15,43 @@ class PointParticle:
 
     def __init__(
         self,
-        position: vectors.PositionVector = np.array([0, 0, 0]),
-        velocity: vectors.VelocityVector = np.array([0, 0, 0]),
-        acceleration: vectors.AccelerationVector = np.array([0, 0, 0]),
-        mass: np.float64 = np.float64(1.0),
-        charge: np.float64 = np.float64(0.0),
+        position: vectors.PositionVector = np.array([0.0, 0.0, 0.0]),
+        velocity: vectors.VelocityVector = np.array([0.0, 0.0, 0.0]),
+        acceleration: vectors.AccelerationVector = np.array([0.0, 0.0, 0.0]),
+        mass: float = 1.0,
+        charge: float = 0.0,
         fixed: bool = False
     ) -> None:
         """Initialize a single point particle with a position, charge, and mass.
 
         Parameters
         ----------
-        position : vectors.PositionVector
-            The initial position of the particle.
-            X is left/right, Y is forward/backward, Z is up/down.
-            Specified in meters(m). 
-        velocity : vectors.VelocityVector
-            The initial velocity of the particle.
-            X is left/right, Y is forward/backward, Z is up/down.
-            Specified in meters per second(m/s). 
-        acceleration : AccelerationVector
-            The initial acceleration of the particle.
-            X is left/right, Y is forward/backward, Z is up/down.
-            Specified in meters per second squared(m/s^2). 
-        mass : np.float64, optional
-            The mass of the charged particle in kilograms, by default 1.0
-        charge : np.float64, optional
-            The charge of the particle in coulombs, by default 0.0
+        position : vectors.PositionVector, optional
+            The initial position of the particle in 3D space.
+            x is left/right, y is forward/backward, z is up/down.
+            Specified in meters(m), by default np.array([0.0, 0.0, 0.0])
+        velocity : vectors.VelocityVector, optional
+            The initial velocity of the particle in 3D space.
+            x is left/right, y is forward/backward, z is up/down.
+            Specified in meters per second(m/s), by default np.array([0.0, 0.0, 0.0])
+        acceleration : vectors.AccelerationVector, optional
+            The initial acceleration of the particle in 3D space.
+            x is left/right, y is forward/backward, z is up/down.
+            Specified in meters per second squared(m/s^2), by default np.array([0.0, 0.0, 0.0])
+        mass : float | float, optional
+            The mass of the charged particle in kilograms(kg), by default 1.0
+        charge : float | float, optional
+            The charge of the particle in coulombs(C), by default 0.0
         fixed : bool, optional
             Whether this particle's position is constant, by default False
         """
-        # Represented by arrays of (X, Y, Z).
-        self.position = position.astype(np.float64)
+        # Represented by arrays of (x, y, z).
+        self.position = position
         self.velocity = velocity
         self.acceleration = acceleration
 
-        self.mass = mass
-        self.charge = charge
+        self.mass = np.float64(mass)
+        self.charge = np.float64(charge)
 
         self.fixed = fixed
         """Whether this particle's position is constant."""

--- a/src/plot.py
+++ b/src/plot.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 
 class Plot():
-    def __init__(self, data_frame: pd.DataFrame, tick_size: np.float64 = np.float64(1.0)) -> None:
+    def __init__(self, data_frame: pd.DataFrame, tick_size: float = 1.0) -> None:
         """Create a 3D NumPy plot.
 
         Parameters
@@ -13,7 +13,7 @@ class Plot():
         data_frame : pd.DataFrame
             A data frame with four columns: t, x, y, z
             Contains the time and position of particles.
-        tick_size : np.float64, optional
+        tick_size : float, optional
             The amount of time between each frame, by default 1.0
         """
         fig = plt.figure()

--- a/src/wires.py
+++ b/src/wires.py
@@ -55,18 +55,18 @@ class Wire():
     def __init__(
         self,
         points: npt.NDArray[np.float64],
-        mass: np.float64 = np.float64(1.0),
-        resistance: np.float64 = np.float64(1.0),
+        mass: float = 1.0,
+        resistance: float = 1.0,
     ) -> None:
         """Initiate a straight current-carrying wire.
 
         Parameters
         ----------
-        points : npt.NDArray[np.float64]
+        points : npt.NDArray[float]
             A 2D array of the points that the wire connects.
-        mass : np.float64
+        mass : float
             The total mass of the wire in kilograms(kg). Greater than 0, by default 1.0
-        resistance : np.float64
+        resistance : float
             The resistance of the wire in ohms(Ω). Greater than 0, by default 1.0
         """
         self.points = points
@@ -89,18 +89,18 @@ class Wire():
 
         Returns
         -------
-        npt.NDArray[np.float64]
+        npt.NDArray[float]
             A 3D vector representing the unit vector in the direction of the wire. 
         """
         wire_vector = self.points[1] - self.points[0]
         return wire_vector / np.linalg.norm(wire_vector)
 
-    def get_wire_point(self, distance: np.float64) -> vectors.PositionVector:
+    def get_wire_point(self, distance: float) -> vectors.PositionVector:
         """Returns a point along the wire given a distance from the first point.
 
         Parameters
         ----------
-        distance : np.float64
+        distance : float
             The distance from the start of the wire. 
 
         Returns
@@ -139,12 +139,12 @@ class Wire():
         """
         return (self.points[0] + self.points[1]) / 2.0
 
-    def get_length(self) -> np.float64:
+    def get_length(self) -> float:
         """Calculate the total length of the wire.
 
         Returns
         -------
-        np.float64
+        float
             A scalar value representing the total length of this wire. 
         """
         # Sum the distance between each point
@@ -152,9 +152,9 @@ class Wire():
         for i in range(0, len(self.points) - 1):
             length += np.linalg.norm(self.points[i+1] - self.points[i])
 
-        return np.float64(length)
+        return float(length)
 
-    def get_electromotive_force(self, electric_field: typing.Callable[[vectors.PositionVector], vectors.FieldVector]) -> np.float64:
+    def get_electromotive_force(self, electric_field: typing.Callable[[vectors.PositionVector], vectors.FieldVector]) -> float:
         """Calculate the electromotive force(emf) generated across the wire.
 
         Parameters
@@ -164,7 +164,7 @@ class Wire():
 
         Returns
         -------
-        np.float64
+        float
             The electromotive force across this wire, measured in volts(V).
         """
         # Negative integral of the electric field across the wire.
@@ -177,7 +177,7 @@ class Wire():
             self.get_length()
         )[0]
 
-    def get_current(self, electric_field: typing.Callable[[vectors.PositionVector], vectors.FieldVector]) -> np.float64:
+    def get_current(self, electric_field: typing.Callable[[vectors.PositionVector], vectors.FieldVector]) -> float:
         """Calculate the current flowing through this wire.
 
         Parameters
@@ -187,7 +187,7 @@ class Wire():
 
         Returns
         -------
-        np.float64
+        float
             The current flowing through this wire, measured in amps(A).
         """
         return self.get_electromotive_force(electric_field) / self.resistance
@@ -202,7 +202,7 @@ class Wire():
         Parameters
         ----------
         vectors.PositionVector
-            A 3D vector of np.float64 representing a point to calculate the magnetic field at.
+            A 3D vector of float representing a point to calculate the magnetic field at.
         electric_field : typing.Callable[[vectors.PositionVector]]
             A function that returns the electric field at any given point.
 
@@ -211,12 +211,12 @@ class Wire():
         vectors.FieldVector
             A 3D vector representing the strength of the magnetic field at the point in teslas(T). 
         """
-        def r(l: np.float64) -> vectors.PositionVector:
+        def r(l: float) -> vectors.PositionVector:
             """Calculate r, the 3D vector between the magnetic field point and the point of integration.
 
             Parameters
             ----------
-            l : np.float64
+            l : float
                 The distance along this wire from `start_point` in meters.
 
             Returns

--- a/src/wires_test.py
+++ b/src/wires_test.py
@@ -10,7 +10,7 @@ points = np.array(
     )
 )
 
-wire = Wire(points, np.float64(1.0))
+wire = Wire(points, 1.0)
 constant_electric_field = np.array((100, 0.0, 0.0))
 particles = ()
 


### PR DESCRIPTION
For example, all instaces of `np.float64` have been changed to `float`.
