### PR TITLE
Correct formatting in `README.md` and `particle.json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ All numbers are in SI units.
 
 ### Schemas
 
-The [./schemas](./schemas/) directory contains the JSON schemas used to validate and generate configuration files.
+The [`./schemas`](./schemas/) directory contains the JSON schemas used to validate and generate configuration files.
 
 > [!Caution]
 > It is recommended that you do not edit the schemas.
@@ -16,20 +16,20 @@ The [./schemas](./schemas/) directory contains the JSON schemas used to validate
 
 ### Configuration Files
 
-The configuration files are used to set up the simulation and are located in [config/](./config/).
-Each configuration file is a JSON file validated using the [main.json schema](./schemas/main.json).
+The configuration files are used to set up the simulation and are located in [`config/`](./config/).
+Each configuration file is a JSON file validated using the [`main.json` schema](./schemas/main.json).
 Running `python src/files.py {configuration file name}` will create a JSON object full of blank values.
 
 ## Running the Simulation
 
 To run the simulation, type `python src/main.py config/{configuration file name}`.
-The file name should contain the file extension(i.e. '.json').
+The file name should contain the file extension(i.e. `.json`).
 
 ## Output Files
 
-The output files, located in [output/](./output/), store records of the state of the particles over time.
-The output file will have the same base name as the configuration file but will have a file extension of '.txt' instead.
-A sample output file named [sample.txt](./output/sample.txt) is provided.
+The output files, located in [`output/`](./output/), store records of the state of the particles over time.
+The output file will have the same base name as the configuration file but will have a file extension of `.txt` instead.
+A sample output file named [`sample.txt`](./output/sample.txt) is provided.
 
 ## Citations
 

--- a/animate.py
+++ b/animate.py
@@ -2,20 +2,22 @@ import matplotlib.pylab as plt
 from matplotlib import animation
 
 FPS = 12
-FRAMES = range(30,90) # iterator for animate function
+FRAMES = range(30, 90)  # iterator for animate function
 FILENAME = 'basic_animation.mp4'
 
 # Create fig and axes
-fig, ax = plt.subplots(figsize=(20,10))
+fig, ax = plt.subplots(figsize=(20, 10))
+
 
 def animate(i):
-  ax.clear() # Clear ax (use if each frame is redrawn from scratch)
-  # Draw plot
-  # ax.plot ...
-  # ax.plot ...
+    ax.clear()  # Clear ax (use if each frame is redrawn from scratch)
+    # Draw plot
+    # ax.plot ...
+    # ax.plot ...
+
 
 # Render video
-anim = animation.FuncAnimation(fig, animate, frames=FRAMES , interval=20)
+anim = animation.FuncAnimation(fig, animate, frames=FRAMES, interval=20)
 writervideo = animation.FFMpegWriter(fps=FPS)
 anim.save(FILENAME, writer=writervideo)
 plt.close()

--- a/schemas/particle.json
+++ b/schemas/particle.json
@@ -1,36 +1,35 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "particle.json",
-  "title": "Point particle",
-  "description": "A point particle with a specified position, charge, and mass.",
-  "type": "object",
-  "properties": {
-    "position": {
-      "description": "The initial position of the particle as a 3D vector, measured in meters(m).",
-      "$ref": "3d_vector.json"
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "particle.json",
+    "title": "Point particle",
+    "description": "A point particle with a specified position, charge, and mass.",
+    "type": "object",
+    "properties": {
+        "position": {
+            "description": "The initial position of the particle as a 3D vector, measured in meters(m).",
+            "$ref": "3d_vector.json"
+        },
+        "velocity": {
+            "description": "The initial velocity of the particle as a 3D vector, measured in meters per second(m/s).",
+            "$ref": "3d_vector.json"
+        },
+        "acceleration": {
+            "description": "The initial acceleration of the particle as a 3D vector, measured in meters per second squared(m/s^2).",
+            "$ref": "3d_vector.json"
+        },
+        "mass": {
+            "description": "The mass of the particle in kilograms(kg).",
+            "type": "number",
+            "exclusiveMinimum": 0
+        },
+        "charge": {
+            "description": "The charge of the particle in coulombs(C).",
+            "type": "number"
+        },
+        "fixed": {
+            "description": "Whether the particle can move.",
+            "type": "boolean"
+        }
     },
-    "velocity": {
-      "description": "The initial velocity of the particle as a 3D vector, measured in meters per second(m/s).",
-      "$ref": "3d_vector.json"
-      
-    },
-    "acceleration": {
-      "description": "The initial acceleration of the particle as a 3D vector, measured in meters per second squared(m/s^2).",
-      "$ref": "3d_vector.json"
-    },
-    "mass": {
-      "description": "The mass of the particle in kilograms(kg).",
-      "type": "number",
-      "exclusiveMinimum": 0
-    },
-    "charge": {
-      "description": "The charge of the particle in coulombs(C).",
-      "type": "number"
-    },
-    "fixed": {
-      "description": "Whether the particle can move.",
-      "type": "boolean"
-    }
-  },
-  "required": ["mass"]
+    "required": ["mass"]
 }


### PR DESCRIPTION
Wrap code quotes around file names and paths in `README.md` and autoformat `particle.json`.
