### PR TITLE
Fix typing problem with constant, uniform fields.

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -193,9 +193,9 @@ if __name__ == '__main__':
     # Create and run the simulation
     simulation = Simulation(
         tick_size=file_data['tick size'],
-        gravitational_field=file_data['gravitational field'],
-        electric_field=file_data['electric field'],
-        magnetic_field=file_data['magnetic field'],
+        gravitational_field=np.array(file_data['gravitational field']),
+        electric_field=np.array(file_data['electric field']),
+        magnetic_field=np.array(file_data['magnetic field']),
         particles=particles
     )
     simulation.run(file_handler=file_handler, print_progress=True)


### PR DESCRIPTION
They were treated as native Python lists, which caused a typing error
when multiplied by a float.
