### PR TITLE
Instead of returning `r` as the magnetic force of a particle when `r` is (0, 0, 0) return (0, 0, 0)

### DIFF
--- a/src/particle.py
+++ b/src/particle.py
@@ -169,7 +169,7 @@ class PointParticle:
         r = point - self.position
         # If the points are overlapping, there is no force.
         if np.all(r == 0):
-            return r
+            return np.zeros(3, dtype=np.float64)
 
         distance = np.linalg.norm(r)
 


### PR DESCRIPTION
It improves clarity.
