### PR TITLE
Fix some problems with ticks

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ The [`./schemas`](./schemas/) directory contains the JSON schemas used to valida
 The input files set up the simulation and are located in [`input/`](./input/).
 Each input file is a JSON file validated using the schema in [`main.json`](./schemas/main.json).
 
+The `num ticks` property of the input file dictates how many ticks the simulator runs.
+If it is set to 0, only the initial state will be given.
+
 Running `python src/files.py <input file name>` will create a JSON object filled with default values.
 
 ### Running the Simulation

--- a/schemas/main.json
+++ b/schemas/main.json
@@ -19,7 +19,7 @@
         "num ticks": {
             "description": "The duration of the simulation as measured in ticks.",
             "type": "integer",
-            "exclusiveMinimum": 0,
+            "minimum": 0,
             "default": 60
         },
         "gravitational field": {

--- a/src/main.py
+++ b/src/main.py
@@ -171,10 +171,14 @@ class Simulation():
             # Log initial particle states
             output_string += self.get_particle_positions_string()
 
+        # Log initial state
+        for particle in particles:
+            self.log_particle_position(particle)
+
         # Run the necessary number of ticks
         for i in range(int(num_ticks)):
             self.tick()
-            progress = i / num_ticks if num_ticks == 0 else float(1.0)
+            progress = i / num_ticks
 
             if print_progress:
                 # Clear the previous line.


### PR DESCRIPTION
Fix a problem where progress was always displayed as 100%.
It attempted to check for a divide by zero and print 100%
if the number of ticks was zero, but it instead printed 100%
when the number of ticks was *not* zero.

Fix another problem where the initial state of the particles was not plotted.
Change number of ticks so that setting the simulation to 0 ticks
will only run the initial state.
