### PR TITLE
Fix problem in progress.

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -178,7 +178,7 @@ class Simulation():
         # Run the necessary number of ticks
         for i in range(int(num_ticks)):
             self.tick()
-            progress = i / num_ticks
+            progress = (i + 1) / num_ticks
 
             if print_progress:
                 # Clear the previous line.


### PR DESCRIPTION
Progress never reaches 100% because Python loops are exclusive,
so dividing `i` by the number of loops always results in a number less than 1.
