### PR TITLE
Fix progress errors

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -175,15 +175,17 @@ class Simulation():
         for particle in particles:
             self.log_particle_position(particle)
 
-        progress = 0
-        print(f'Progress: {round(progress * 100, 1)}%', end='\r')
+        if print_progress:
+            progress = 0.0
+            print(f'Progress: {progress}%', end='\r')
 
         # Run the necessary number of ticks
         for i in range(int(num_ticks)):
             self.tick()
-            progress = (i + 1) / num_ticks
 
             if print_progress:
+                progress = (i + 1) / num_ticks
+
                 # Clear the previous line.
                 sys.stdout.write('\033[K')
                 # Print the current progress and then return to the beginning of the line.


### PR DESCRIPTION
Prevent progress from printing 0% progress when progres printing is suppressed.
Prevent progress calculations when not printing progress.
