### PR TITLE
Change default number of ticks from 60 to 600.

### DIFF
--- a/schemas/main.json
+++ b/schemas/main.json
@@ -20,7 +20,7 @@
             "description": "The duration of the simulation as measured in ticks.",
             "type": "integer",
             "minimum": 0,
-            "default": 60
+            "default": 600
         },
         "gravitational field": {
             "description": "The constant gravitational field as 3D vector, measured in newtons per kilogram(N/kg).",


### PR DESCRIPTION
The defauult tick size is 0.1, so 600 ticks gives a nice, round 1 minute.
